### PR TITLE
Disable self_accessor since it's throwing a false positive

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -236,7 +236,6 @@ class Ruleset
             'regular_callable_call' => true,
             'return_assignment' => true,
             'set_type_to_cast' => true,
-            'self_accessor' => true,
             'self_static_accessor' => true,
             'semicolon_after_instruction' => true,
             'simple_to_complex_string_variable' => true,


### PR DESCRIPTION
It's valid to have a function on an interface return an instance of itself. But when implementing the interface, changing it to self does not mean the same thing. I may want to return another class that implements that interface and not necessarily the same class.